### PR TITLE
Fix page error on refresh and update HistoryEditor styles

### DIFF
--- a/frontend/src/components/History/HistoryEditor/HistoryEditor.module.css
+++ b/frontend/src/components/History/HistoryEditor/HistoryEditor.module.css
@@ -23,7 +23,6 @@
 
 .description {
   position: relative;
-  /* flex: 1; */
   margin-right: 10px;
   overflow:scroll;           
   text-overflow: ellipsis;

--- a/frontend/src/components/History/HistoryEditor/HistoryEditor.module.css
+++ b/frontend/src/components/History/HistoryEditor/HistoryEditor.module.css
@@ -11,19 +11,34 @@
 .bodyContainer {
   position: absolute;
   display: flex;
-  height: 70%;
+  height: 80%;
   width: 95%;
 }
 
+.detailsContainer {
+  display: flex;
+  flex-direction: column;
+  flex:0.5;
+}
+
 .description {
-  flex: 0.5;
+  position: relative;
+  /* flex: 1; */
   margin-right: 10px;
+  overflow:scroll;           
+  text-overflow: ellipsis;
+}
+
+.checkout {
+  position: absolute;
+  margin-top: 15px;
 }
 
 .inputContainer {
   position: relative;
   flex: 1;
   resize: none;
+  height: 90%;
   border: 1px solid #ccc;
   border-radius: 4px;
   resize: none;

--- a/frontend/src/components/History/HistoryEditor/HistoryEditor.tsx
+++ b/frontend/src/components/History/HistoryEditor/HistoryEditor.tsx
@@ -16,6 +16,7 @@ import {
 } from "@chakra-ui/react";
 import { useState } from "react";
 import { useAuth } from "@/utils/auth";
+import Link from "next/link";
 
 interface IOwnProps {
   attempt: Attempt;
@@ -74,16 +75,22 @@ export default function HistoryEditor({
         <ModalHeader>{attempt.title}</ModalHeader>
         <ModalCloseButton />
         <ModalBody className={styles.body}>
-          <div className={styles.date}>{attempt.date}</div>
-          <div className={styles.bodyContainer}>
-            <div className={styles.description}>
-              {attempt.description.split("\n").map((desc, index) => (
-                <p key={index}>
-                  {desc}
-                  <br />
-                </p>
-              ))}
+            <div className={styles.bodyContainer}>
+              <div className={styles.detailsContainer}>
+                <div className={styles.date}>{attempt.date}</div>
+                  <div className={styles.description}>
+                    {attempt.description.split("\n").map((desc, index) => (
+                      <p key={index}>
+                        {desc}
+                        <br />
+                      </p>
+                    ))}
+                  </div>
+                <Link href={attempt.link}>
+                  <Button colorScheme="gray" className={styles.checkout}>Check out here</Button>
+                </Link>
             </div>
+            
             <div className={styles.inputContainer}>
               <div className={styles.selectContainer}>
                 <Select
@@ -112,7 +119,7 @@ export default function HistoryEditor({
                 onChange={(e) => handleCodeChange(e)}
               />
             </div>
-          </div>
+          </div> 
         </ModalBody>
         <ModalFooter>
           <Button colorScheme="green" onClick={() => updateAttempt()}>

--- a/frontend/src/components/History/HistoryEditor/HistoryEditor.tsx
+++ b/frontend/src/components/History/HistoryEditor/HistoryEditor.tsx
@@ -17,6 +17,7 @@ import {
 import { useState } from "react";
 import { useAuth } from "@/utils/auth";
 import Link from "next/link";
+import QuestionDescription from "@/components/Questions/QuestionDescription/QuestionDescription";
 
 interface IOwnProps {
   attempt: Attempt;
@@ -78,14 +79,9 @@ export default function HistoryEditor({
             <div className={styles.bodyContainer}>
               <div className={styles.detailsContainer}>
                 <div className={styles.date}>{attempt.date}</div>
-                  <div className={styles.description}>
-                    {attempt.description.split("\n").map((desc, index) => (
-                      <p key={index}>
-                        {desc}
-                        <br />
-                      </p>
-                    ))}
-                  </div>
+                <div className={styles.description}>
+                  <QuestionDescription description={attempt.description}/>
+                </div>
                 <Link href={attempt.link}>
                   <Button colorScheme="gray" className={styles.checkout}>Check out here</Button>
                 </Link>

--- a/frontend/src/pages/history.tsx
+++ b/frontend/src/pages/history.tsx
@@ -20,6 +20,10 @@ export default function History() {
   const [history, setHistory] = useState<Attempt[]>([]);
 
   async function fetchData() {
+    if (!token) {
+      setStatus(Status.Loading);
+      return;
+    }
     try {
       const results = await fetchAllHistoryByUser(token);
       setHistory(results);
@@ -29,9 +33,10 @@ export default function History() {
       setStatus(Status.Error);
     }
   }
+
   useEffect(() => {
     fetchData();
-  }, []);
+  }, [token]);
 
   if (authRedirect.isLoading) return <></>;
 


### PR DESCRIPTION
1. Fix issue where refreshing the page would throw an `unauthorized` error as token is still empty when calling `fetchData`.
2. Add link to Leetcode question in `HistoryEditor` and truncate text on overflow.